### PR TITLE
Fix 11 add travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: python
+python:
+  - "2.7"
+install: "python setup.py install"
+script: "python setup.py test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,20 @@ python:
 addons:
   apt:
     packages:
-      - python-gtk2
-      - python-gtk2-dev
       - libgtk2.0-dev
       - libglib2.0-dev
+before_install:
+  - export PYGTK_VERSION=2.24.0
+  - export PYGTK_PATH=$HOME/pygtk/
+  - export PYGTK_INST=$HOME/pygtk-inst/
+  - mkdir $PYGTK_PATH
+  - cd $PYGTK_PATH
+  - wget http://ftp.gnome.org/pub/GNOME/sources/pygtk/2.24/pygtk-"$PYGTK_VERSION".tar.bz2 -O pygtk.tar.bz2
+  - tar -xf pygtk.tar.bz2
+  - cd pygtk-"$PYGTK_VERSION"
+  - ./configure --prefix=$PYGTK_INST
+  - make
+  - sudo make install
 install:
   - python setup.py install
 script: "python setup.py test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 before_install:
   - sudo apt-add-repository --yes ppa:zoogie/sdl2-snapshots
   - sudo apt-get update -qq
-  - sudo apt-get install libgtk2.0-dev libglib2.0-dev libgirepository1.0-dev python-pygame libcairo2-dev libatk1.0-dev libsdl2-dev libsmpeg-dev
+  - sudo apt-get install libgtk2.0-dev libglib2.0-dev libgirepository1.0-dev python-pygame libcairo2-dev libatk1.0-dev libsdl2-dev libsmpeg-dev ibsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsmpeg-dev libsdl1.2-dev libportmidi-dev libswscale-dev libavformat-dev libavcodec-dev
 install:
 # Environment setup
   - export VIRT_ROOT=/home/travis/virtualenv/python$TRAVIS_PYTHON_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "2.7"
 before_install:
-  - sudo apt-get install python-gtk2 python-gtk2-dev
+  - sudo apt-get install python-gtk2 python-gtk2-dev libgtk2.0-dev libglib2.0-dev
 install:
   - python setup.py install
 script: "python setup.py test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ before_install:
   - sudo apt-add-repository --yes ppa:zoogie/sdl2-snapshots
   - sudo apt-get update -qq
   - sudo apt-get install libgtk2.0-dev libglib2.0-dev libgirepository1.0-dev python-pygame libcairo2-dev libatk1.0-dev libsdl2-dev libsmpeg-dev ibsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsmpeg-dev libsdl1.2-dev libportmidi-dev libswscale-dev libavformat-dev libavcodec-dev
-install:
 # Environment setup
   - export VIRT_ROOT=/home/travis/virtualenv/python$TRAVIS_PYTHON_VERSION
   - export PKG_CONFIG_PATH=$VIRT_ROOT/lib/pkgconfig
@@ -33,4 +32,6 @@ install:
   - make > /dev/null
   - make install > /dev/null
   - cd ..
-script: "python setup.py test"
+install:
+  - python setup.py install
+script: python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "2.7"
 before_install:
+  - sudo apt-add-repository --yes ppa:zoogie/sdl2-snapshots
   - sudo apt-get update -qq
   - sudo apt-get install libgtk2.0-dev libglib2.0-dev libgirepository1.0-dev python-pygame libcairo2-dev libatk1.0-dev libsdl2-dev libsmpeg-dev
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - export PYGOB_PATH=$WORKDIR/pygob/$PYGOB_VERSION
   - mkdir -p $PYGOB_PATH
   - cd $PYGOB_PATH
-  - wget http://ftp.gnome.org/pub/GNOME/sources/pygobject/3.10/pygobject-"$PYGOB_VERSION".tar.xz -O pygob.tar.xz
+  - wget http://ftp.gnome.org/pub/GNOME/sources/pygobject/2.90/pygobject-"$PYGOB_VERSION".tar.xz -O pygob.tar.xz
   - tar -xf pygob.tar.xz
   - cd pygobject-"$PYGOB_VERSION"/
   - ./configure

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ addons:
     packages:
       - libgtk2.0-dev
       - libglib2.0-dev
+      - libgirepository1.0-dev
 before_install:
   - # Where to build things
   - export WORKDIR=$HOME/build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
       - python-gobject-dev
 before_install:
   - # Where to build things
-  - # export WORKDIR=$HOME/build/
+  - export WORKDIR=$HOME/build/
   - # export PYGOB_VERSION=2.90.4
   - # export PYGOB_PATH=$WORKDIR/pygob/$PYGOB_VERSION
   - # mkdir -p $PYGOB_PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
       - python-cairo-dev
       - python-gobject
       - python-gobject-dev
+      - python-pygame
 before_install:
   - export WORKDIR=$HOME/build/
   - export PYGTK_VERSION=2.24.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,19 +9,21 @@ addons:
       - libgirepository1.0-dev
       - python-cairo
       - python-cairo-dev
+      - python-gobject
+      - python-gobject-dev
 before_install:
   - # Where to build things
-  - export WORKDIR=$HOME/build/
-  - export PYGOB_VERSION=2.90.4
-  - export PYGOB_PATH=$WORKDIR/pygob/$PYGOB_VERSION
-  - mkdir -p $PYGOB_PATH
-  - cd $PYGOB_PATH
-  - wget http://ftp.gnome.org/pub/GNOME/sources/pygobject/2.90/pygobject-"$PYGOB_VERSION".tar.xz -O pygob.tar.xz
-  - tar -xf pygob.tar.xz
-  - cd pygobject-"$PYGOB_VERSION"/
-  - ./configure
-  - make
-  - sudo make install
+  - # export WORKDIR=$HOME/build/
+  - # export PYGOB_VERSION=2.90.4
+  - # export PYGOB_PATH=$WORKDIR/pygob/$PYGOB_VERSION
+  - # mkdir -p $PYGOB_PATH
+  - # cd $PYGOB_PATH
+  - # wget http://ftp.gnome.org/pub/GNOME/sources/pygobject/2.90/pygobject-"$PYGOB_VERSION".tar.xz -O pygob.tar.xz
+  - # tar -xf pygob.tar.xz
+  - # cd pygobject-"$PYGOB_VERSION"/
+  - # ./configure
+  - # make
+  - # sudo make install
   - export PYGTK_VERSION=2.24.0
   - export PYGTK_PATH=$WORKDIR/pygtk/$PYGTK_VERSION
   - mkdir -p $PYGTK_PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,26 @@ addons:
       - libgtk2.0-dev
       - libglib2.0-dev
 before_install:
+  - # Where to build things
+  - export WORKDIR=$HOME/build/
+  - export PYGOB_VERSION=3.10.1
+  - export PYGOB_PATH=$WORKDIR/pygob/$PYGOB_VERSION
+  - mkdir -p $PYGOB_PATH
+  - cd $PYGOB_PATH
+  - wget http://ftp.gnome.org/pub/GNOME/sources/pygobject/3.10/pygobject-"$PYGOB_VERSION".tar.xz -O pygob.tar.xz
+  - tar -xf pygob.tar.xz
+  - cd pygobject-"$PYGOB_VERSION"/
+  - ./configure
+  - make
+  - sudo make install
   - export PYGTK_VERSION=2.24.0
-  - export PYGTK_PATH=$HOME/pygtk/
-  - export PYGTK_INST=$HOME/pygtk-inst/
-  - mkdir $PYGTK_PATH
+  - export PYGTK_PATH=$WORKDIR/pygtk/$PYGTK_VERSION
+  - mkdir -p $PYGTK_PATH
   - cd $PYGTK_PATH
   - wget http://ftp.gnome.org/pub/GNOME/sources/pygtk/2.24/pygtk-"$PYGTK_VERSION".tar.bz2 -O pygtk.tar.bz2
   - tar -xf pygtk.tar.bz2
-  - cd pygtk-"$PYGTK_VERSION"
-  - ./configure --prefix=$PYGTK_INST
+  - cd pygtk-"$PYGTK_VERSION"/
+  - ./configure
   - make
   - sudo make install
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: python
 python:
   - "2.7"
-before_install:
-  - sudo apt-get install python-gtk2 python-gtk2-dev libgtk2.0-dev libglib2.0-dev
 install:
+  - sudo apt-get install python-gtk2 python-gtk2-dev libgtk2.0-dev libglib2.0-dev
   - python setup.py install
 script: "python setup.py test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 before_install:
   - sudo apt-add-repository --yes ppa:zoogie/sdl2-snapshots
   - sudo apt-get update -qq
-  - sudo apt-get install libgtk2.0-dev libglib2.0-dev libgirepository1.0-dev python-pygame libcairo2-dev libatk1.0-dev libsdl2-dev libsmpeg-dev ibsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsmpeg-dev libsdl1.2-dev libportmidi-dev libswscale-dev libavformat-dev libavcodec-dev
+  - sudo apt-get install libgtk2.0-dev libglib2.0-dev libgirepository1.0-dev python-pygame libcairo2-dev libatk1.0-dev libsdl2-dev libsmpeg-dev ibsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsmpeg-dev libsdl1.2-dev libportmidi-dev libswscale-dev libavformat-dev libavcodec-dev python-gdbm python-bsddb3
 # Environment setup
   - export VIRT_ROOT=/home/travis/virtualenv/python$TRAVIS_PYTHON_VERSION
   - export PKG_CONFIG_PATH=$VIRT_ROOT/lib/pkgconfig

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 python:
   - "2.7"
-install: "python setup.py install"
+before_install:
+  - sudo apt-get install python-gtk2 python-gtk2-dev
+install:
+  - python setup.py install
 script: "python setup.py test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,18 +12,7 @@ addons:
       - python-gobject
       - python-gobject-dev
 before_install:
-  - # Where to build things
   - export WORKDIR=$HOME/build/
-  - # export PYGOB_VERSION=2.90.4
-  - # export PYGOB_PATH=$WORKDIR/pygob/$PYGOB_VERSION
-  - # mkdir -p $PYGOB_PATH
-  - # cd $PYGOB_PATH
-  - # wget http://ftp.gnome.org/pub/GNOME/sources/pygobject/2.90/pygobject-"$PYGOB_VERSION".tar.xz -O pygob.tar.xz
-  - # tar -xf pygob.tar.xz
-  - # cd pygobject-"$PYGOB_VERSION"/
-  - # ./configure
-  - # make
-  - # sudo make install
   - export PYGTK_VERSION=2.24.0
   - export PYGTK_PATH=$WORKDIR/pygtk/$PYGTK_VERSION
   - mkdir -p $PYGTK_PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "2.7"
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install libgtk2.0-dev libglib2.0-dev libgirepository1.0-dev python-cairo python-cairo-dev python-gobject2 python-gobject2-dev python-pygame
+  - sudo apt-get install libgtk2.0-dev libglib2.0-dev libgirepository1.0-dev python-cairo python-cairo-dev python-gobject python-gobject-dev python-pygame
 install:
   - export WORKDIR=$HOME/build/
   - export PYGTK_VERSION=2.24.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "2.7"
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install libgtk2.0-dev libglib2.0-dev libgirepository1.0-dev python-pygame libcairo2-dev libatk1.0-devA libsdl2-dev libsmpeg-dev
+  - sudo apt-get install libgtk2.0-dev libglib2.0-dev libgirepository1.0-dev python-pygame libcairo2-dev libatk1.0-dev libsdl2-dev libsmpeg-dev
 install:
 # Environment setup
   - export VIRT_ROOT=/home/travis/virtualenv/python$TRAVIS_PYTHON_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 language: python
 python:
   - "2.7"
+addons:
+  apt:
+    packages:
+      - python-gtk2
+      - python-gtk2-dev
+      - libgtk2.0-dev
+      - libglib2.0-dev
 install:
-  - sudo apt-get install python-gtk2 python-gtk2-dev libgtk2.0-dev libglib2.0-dev
   - python setup.py install
 script: "python setup.py test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
       - python-gobject
       - python-gobject-dev
       - python-pygame
-before_install:
+install:
   - export WORKDIR=$HOME/build/
   - export PYGTK_VERSION=2.24.0
   - export PYGTK_PATH=$WORKDIR/pygtk/$PYGTK_VERSION
@@ -21,9 +21,8 @@ before_install:
   - wget http://ftp.gnome.org/pub/GNOME/sources/pygtk/2.24/pygtk-"$PYGTK_VERSION".tar.bz2 -O pygtk.tar.bz2
   - tar -xf pygtk.tar.bz2
   - cd pygtk-"$PYGTK_VERSION"/
-  - ./configure
+  - ./configure --prefix=/home/travis/virtualenv/python$TRAVIS_PYTHON_VERSION
   - make
   - sudo make install
-install:
   - python setup.py install
 script: "python setup.py test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ addons:
       - libgtk2.0-dev
       - libglib2.0-dev
       - libgirepository1.0-dev
+      - python-cairo
+      - python-cairo-dev
 before_install:
   - # Where to build things
   - export WORKDIR=$HOME/build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ addons:
 before_install:
   - # Where to build things
   - export WORKDIR=$HOME/build/
-  - export PYGOB_VERSION=3.10.1
+  - export PYGOB_VERSION=2.90.4
   - export PYGOB_PATH=$WORKDIR/pygob/$PYGOB_VERSION
   - mkdir -p $PYGOB_PATH
   - cd $PYGOB_PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,33 @@ python:
   - "2.7"
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install libgtk2.0-dev libglib2.0-dev libgirepository1.0-dev python-cairo python-cairo-dev python-gobject python-gobject-dev python-pygame
+  - sudo apt-get install libgtk2.0-dev libglib2.0-dev libgirepository1.0-dev python-pygame
 install:
-  - export WORKDIR=$HOME/build/
-  - export PYGTK_VERSION=2.24.0
-  - export PYGTK_PATH=$WORKDIR/pygtk/$PYGTK_VERSION
-  - mkdir -p $PYGTK_PATH
-  - cd $PYGTK_PATH
-  - wget http://ftp.gnome.org/pub/GNOME/sources/pygtk/2.24/pygtk-"$PYGTK_VERSION".tar.bz2 -O pygtk.tar.bz2
-  - tar -xf pygtk.tar.bz2
-  - cd pygtk-"$PYGTK_VERSION"/
-  - ./configure --prefix=/home/travis/virtualenv/python$TRAVIS_PYTHON_VERSION
-  - make
-  - make install
+# Environment setup
+  - export VIRT_ROOT=/home/travis/virtualenv/python$TRAVIS_PYTHON_VERSION
+  - export PKG_CONFIG_PATH=$VIRT_ROOT/lib/pkgconfig
+# PyCairo
+  - wget http://www.cairographics.org/releases/py2cairo-1.10.0.tar.bz2
+  - tar xf py2cairo-1.10.0.tar.bz2
+  - cd py2cairo-1.10.0
+  - ./waf configure --prefix=$VIRT_ROOT > /dev/null
+  - ./waf build > /dev/null
+  - ./waf install > /dev/null
+  - cd ..
+# PyGobject
+  - wget http://ftp.gnome.org/pub/GNOME/sources/pygobject/2.28/pygobject-2.28.6.tar.bz2
+  - tar xf pygobject-2.28.6.tar.bz2
+  - cd pygobject-2.28.6
+  - ./configure --prefix=$VIRT_ROOT --disable-introspection > /dev/null
+  - make > /dev/null
+  - make install > /dev/null
+  - cd ..
+# PyGtk
+  - wget http://ftp.gnome.org/pub/GNOME/sources/pygtk/2.24/pygtk-2.24.0.tar.bz2
+  - tar xf pygtk-2.24.0.tar.bz2
+  - cd pygtk-2.24.0
+  - ./configure --prefix=$VIRT_ROOT > /dev/null
+  - make > /dev/null
+  - make install > /dev/null
+  - cd ..
 script: "python setup.py test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "2.7"
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install libgtk2.0-dev libglib2.0-dev libgirepository1.0-dev python-pygame
+  - sudo apt-get install libgtk2.0-dev libglib2.0-dev libgirepository1.0-dev python-pygame libcairo2-dev libatk1.0-devA libsdl2-dev libsmpeg-dev
 install:
 # Environment setup
   - export VIRT_ROOT=/home/travis/virtualenv/python$TRAVIS_PYTHON_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,10 @@
 language: python
 python:
   - "2.7"
-addons:
-  apt:
-    packages:
-      - libgtk2.0-dev
-      - libglib2.0-dev
-      - libgirepository1.0-dev
-      - python-cairo
-      - python-cairo-dev
-      - python-gobject
-      - python-gobject-dev
-      - python-pygame
 before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install libgtk2.0-dev libglib2.0-dev libgirepository1.0-dev python-cairo python-cairo-dev python-gobject2 python-gobject2-dev python-pygame
+install:
   - export WORKDIR=$HOME/build/
   - export PYGTK_VERSION=2.24.0
   - export PYGTK_PATH=$WORKDIR/pygtk/$PYGTK_VERSION
@@ -23,5 +15,5 @@ before_install:
   - cd pygtk-"$PYGTK_VERSION"/
   - ./configure --prefix=/home/travis/virtualenv/python$TRAVIS_PYTHON_VERSION
   - make
-  - sudo make install
+  - make install
 script: "python setup.py test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
       - python-gobject
       - python-gobject-dev
       - python-pygame
-install:
+before_install:
   - export WORKDIR=$HOME/build/
   - export PYGTK_VERSION=2.24.0
   - export PYGTK_PATH=$WORKDIR/pygtk/$PYGTK_VERSION
@@ -24,5 +24,4 @@ install:
   - ./configure --prefix=/home/travis/virtualenv/python$TRAVIS_PYTHON_VERSION
   - make
   - sudo make install
-  - python setup.py install
 script: "python setup.py test"

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,10 @@
 ROBOTICS BASESTATION
 ========
 
+.. image:: https://travis-ci.org/space-concordia-robotics/robotics-basestation.svg
+  :target: https://travis-ci.org/space-concordia-robotics/robotics-basestation
+
+
 Robotics networking stuff.
 
 To install, run:

--- a/roboticsbase/base_window.py
+++ b/roboticsbase/base_window.py
@@ -1,76 +1,84 @@
 from common_constants import *
 import threading
-from controller import spawn_joystick_thread
+
 from roboticsnet.gateway_constants import ROBOTICSNET_PORT
+from mjpg import VideoThread
+import pygtk
+pygtk.require('2.0')
+import gtk
+import urllib
+import gobject
+import threading
+
+from joystick_listener import spawn_joystick_process
+
 
 
 class BaseWindow:
     # Create the base window where all other items will be.
     def __init__(self):
-        self.app_window = gtk.Window(gtk.WINDOW_TOPLEVEL)
-        self.app_window.set_size_request(WINDOW_WIDTH, WINDOW_HEIGHT)
-        self.app_window.set_border_width(WINDOW_BORDER_WIDTH)
-        self.app_window.set_title(WINDOW_TITLE)
-        self.app_window.set_position(gtk.WIN_POS_CENTER)
-
-        ############################
-        # Video Box
-        ############################
-
-        # add video widgets here
-
-
-        self.video_box = gtk.HBox()
+        #this isn't necessary for gobject v~3+. not sure what the version being used is.
+        gobject.threads_init()
+        #main window
+        self.window = gtk.Window(gtk.WINDOW_TOPLEVEL)
+        self.window.connect("destroy", gtk.main_quit)
+        self.window.set_default_size(500, 800)
         
-        ############################
-        # Status Box
-        ############################
-
-        # add status widgets here
-        # self.web = webkit.WebView()
-        # self.web.open("www.google.ca")
-        # self.map = gtk.Frame('Maps')
-        # self.scroll = gtk.ScrolledWindow()
-        # self.scroll.add(self.web)
-        # self.map.add(self.scroll)
-        
-        self.status_box = gtk.HBox()
-        # self.status_box.pack_start(self.map)
-
-        ############################
-        # Control Widgets Box 
-        ############################
-        
-        # Exit button
-        self.exit_button = gtk.Button(stock=gtk.STOCK_QUIT)
-        self.exit_button.connect("clicked", self.destroy)
-
+        #video stream
+        self.img = gtk.Image()
+        self.img2 = gtk.Image()
+        self.img.set_from_stock(gtk.STOCK_MISSING_IMAGE,gtk.ICON_SIZE_DIALOG)
+        self.img2.set_from_stock(gtk.STOCK_MISSING_IMAGE,gtk.ICON_SIZE_DIALOG)
+        self.img.show()
+        self.img2.show()
+        #widget that contains other widgets
+        self.main_box=gtk.VBox()
+        self.main_box.show()
+        #buttons to go inside the widget widget
         self.button1 = gtk.Button("This is button1")
         self.button2 = gtk.Button("This is button2")
 
         self.widget_box = gtk.HBox(False, 0)
+        self.video_box = gtk.HBox(False,0)
+
+        self.video_box.pack_start(self.img)
+        self.video_box.pack_start(self.img2)
         self.widget_box.pack_start(self.button1)    # test button
         self.widget_box.pack_start(self.button2)    # test button
-        self.widget_box.pack_start(self.exit_button)
-
-
-        ###########################
-        # Main window stuff
-        ##########################
-
-        # Put all box into the main one.
-        self.main_box = gtk.VBox()
+        self.button1.set_size_request(400,30)
+        self.button2.set_size_request(400,30)
+        
+        #exit button
+        self.exit_button = gtk.Button(stock=gtk.STOCK_QUIT)
+        self.exit_button.connect("clicked", self.destroy)
+        self.exit_button.set_size_request(400,30)
+        self.widget_box.pack_start(self.exit_button,fill=False)
+        
         self.main_box.pack_start(self.video_box)
-        self.main_box.pack_start(self.status_box)
         self.main_box.pack_start(self.widget_box)
+        self.window.add(self.main_box)
+        self.window.show_all()
 
-        # Show everything in window
-        self.app_window.add(self.main_box)
-        self.app_window.show_all()
 
         # Used when closing window.
-        self.app_window.connect("delete_event", self.delete_event)
-        self.app_window.connect("destroy", self.destroy)
+        self.window.connect("delete_event", self.delete_event)
+        self.window.connect("destroy", self.destroy)
+
+        #creating video thread
+        try:
+            self.t = VideoThread(self.img)
+            self.t2 = VideoThread(self.img2)
+            self.t2.start()
+            self.t.start()
+        except:
+            print "no video stream"
+
+        
+        #spawning joystick thread
+        
+        
+        gtk.main()
+        self.t.quit = True
 
     def delete_event(self, widget, event, data=None):
         msg = "Are you sure you want to quit?"
@@ -98,7 +106,8 @@ class BaseWindow:
         # spawning joystick thread here for now. This functionality could be tied to a button/further integrated with the window
         # furthermore, events in e can be used in the window to trigger events
         e = [threading.Event() for i in range(NUM_BUTTON_EVENTS)]
-        spawn_joystick_thread('localhost', ROBOTICSNET_PORT, e)
+        try:
+            spawn_joystick_thread('localhost', ROBOTICSNET_PORT, e)
+        except:
+            print "no joystick connected"
         gtk.main()
-
-

--- a/roboticsbase/base_window.py
+++ b/roboticsbase/base_window.py
@@ -3,9 +3,11 @@ import threading
 
 from roboticsnet.gateway_constants import ROBOTICSNET_PORT
 from mjpg import VideoThread
+
 import pygtk
 pygtk.require('2.0')
 import gtk
+
 import urllib
 import gobject
 import threading
@@ -23,7 +25,7 @@ class BaseWindow:
         self.window = gtk.Window(gtk.WINDOW_TOPLEVEL)
         self.window.connect("destroy", gtk.main_quit)
         self.window.set_default_size(500, 800)
-        
+
         #video stream
         self.img = gtk.Image()
         self.img2 = gtk.Image()
@@ -47,13 +49,13 @@ class BaseWindow:
         self.widget_box.pack_start(self.button2)    # test button
         self.button1.set_size_request(400,30)
         self.button2.set_size_request(400,30)
-        
+
         #exit button
         self.exit_button = gtk.Button(stock=gtk.STOCK_QUIT)
         self.exit_button.connect("clicked", self.destroy)
         self.exit_button.set_size_request(400,30)
         self.widget_box.pack_start(self.exit_button,fill=False)
-        
+
         self.main_box.pack_start(self.video_box)
         self.main_box.pack_start(self.widget_box)
         self.window.add(self.main_box)
@@ -73,10 +75,10 @@ class BaseWindow:
         except:
             print "no video stream"
 
-        
+
         #spawning joystick thread
-        
-        
+
+
         gtk.main()
         self.t.quit = True
 
@@ -101,7 +103,7 @@ class BaseWindow:
 
     def destroy(self, widget, data=None):
         gtk.main_quit()
-   
+
     def main(self):
         # spawning joystick thread here for now. This functionality could be tied to a button/further integrated with the window
         # furthermore, events in e can be used in the window to trigger events

--- a/roboticsbase/base_window.py
+++ b/roboticsbase/base_window.py
@@ -1,6 +1,5 @@
 from common_constants import *
-import threading
-from controller import spawn_joystick_thread
+from joystick_listener import spawn_joystick_process
 from roboticsnet.gateway_constants import ROBOTICSNET_PORT
 
 
@@ -97,8 +96,9 @@ class BaseWindow:
     def main(self):
         # spawning joystick thread here for now. This functionality could be tied to a button/further integrated with the window
         # furthermore, events in e can be used in the window to trigger events
-        e = [threading.Event() for i in range(NUM_BUTTON_EVENTS)]
-        spawn_joystick_thread('localhost', ROBOTICSNET_PORT, e)
+        events = [multiprocessing.Event() for i in range(NUM_BUTTON_EVENTS)]
+        client_lock = multiprocessing.Lock()
+        spawn_joystick_thread('localhost', ROBOTICSNET_PORT, events, client_lock)
         gtk.main()
 
 

--- a/roboticsbase/base_window.py
+++ b/roboticsbase/base_window.py
@@ -1,6 +1,6 @@
 from common_constants import *
 import threading
-#from controller import spawn_joystick_thread
+
 from roboticsnet.gateway_constants import ROBOTICSNET_PORT
 from mjpg import VideoThread
 import pygtk
@@ -9,6 +9,9 @@ import gtk
 import urllib
 import gobject
 import threading
+
+from joystick_listener import spawn_joystick_process
+
 
 
 class BaseWindow:
@@ -19,28 +22,39 @@ class BaseWindow:
         #main window
         self.window = gtk.Window(gtk.WINDOW_TOPLEVEL)
         self.window.connect("destroy", gtk.main_quit)
-        self.window.set_border_width(10)
+        self.window.set_default_size(500, 800)
+        
         #video stream
         self.img = gtk.Image()
+        self.img2 = gtk.Image()
+        self.img.set_from_stock(gtk.STOCK_MISSING_IMAGE,gtk.ICON_SIZE_DIALOG)
+        self.img2.set_from_stock(gtk.STOCK_MISSING_IMAGE,gtk.ICON_SIZE_DIALOG)
         self.img.show()
+        self.img2.show()
         #widget that contains other widgets
         self.main_box=gtk.VBox()
         self.main_box.show()
         #buttons to go inside the widget widget
         self.button1 = gtk.Button("This is button1")
         self.button2 = gtk.Button("This is button2")
-        
-        self.main_box.pack_start(self.img)
+
         self.widget_box = gtk.HBox(False, 0)
-        #these things should be horizontal, not vertical
+        self.video_box = gtk.HBox(False,0)
+
+        self.video_box.pack_start(self.img)
+        self.video_box.pack_start(self.img2)
         self.widget_box.pack_start(self.button1)    # test button
         self.widget_box.pack_start(self.button2)    # test button
+        self.button1.set_size_request(400,30)
+        self.button2.set_size_request(400,30)
+        
         #exit button
         self.exit_button = gtk.Button(stock=gtk.STOCK_QUIT)
         self.exit_button.connect("clicked", self.destroy)
-        self.widget_box.pack_start(self.exit_button)
+        self.exit_button.set_size_request(400,30)
+        self.widget_box.pack_start(self.exit_button,fill=False)
         
-       
+        self.main_box.pack_start(self.video_box)
         self.main_box.pack_start(self.widget_box)
         self.window.add(self.main_box)
         self.window.show_all()
@@ -51,13 +65,20 @@ class BaseWindow:
         self.window.connect("destroy", self.destroy)
 
         #creating video thread
-        self.t = VideoThread(self.img)
-        self.t.start()
+        try:
+            self.t = VideoThread(self.img)
+            self.t2 = VideoThread(self.img2)
+            self.t2.start()
+            self.t.start()
+        except:
+            print "no video stream"
+
         
         #spawning joystick thread
         
         
         gtk.main()
+        self.t.quit = True
 
     def delete_event(self, widget, event, data=None):
         msg = "Are you sure you want to quit?"
@@ -85,5 +106,8 @@ class BaseWindow:
         # spawning joystick thread here for now. This functionality could be tied to a button/further integrated with the window
         # furthermore, events in e can be used in the window to trigger events
         e = [threading.Event() for i in range(NUM_BUTTON_EVENTS)]
-        #spawn_joystick_thread('localhost', ROBOTICSNET_PORT, e)
+        try:
+            spawn_joystick_thread('localhost', ROBOTICSNET_PORT, e)
+        except:
+            print "no joystick connected"
         gtk.main()

--- a/roboticsbase/bin/roboticsbase-test
+++ b/roboticsbase/bin/roboticsbase-test
@@ -3,6 +3,22 @@
 from roboticsbase.common_constants import *
 from roboticsbase.base_window import BaseWindow
 
+try:
+    import pygtk
+    pygtk.require('2.0')
+    import gtk
+except ImportError:
+    print "You need pygtk 2.x in order to run the basestation software"
+    print "Install pygtk via your distributions recommended way."
+    exit()
+
+try:
+    import pygame
+except ImportError:
+    print "You need to install pygame 1.9.x"
+    print "Install pygame via your distributions recommended way."
+    exit()
+
 def on_right_click(data, event_button, event_time):
     print "herp derp"
 

--- a/roboticsbase/joystick_listener.py
+++ b/roboticsbase/joystick_listener.py
@@ -41,8 +41,12 @@ def joystick_listener(host, port, events, lock, joystick):
     """
     client = RoverClient(host, port)
     print "Controller client established with %s:%d:" % (client.getHost(), client.getPort())
-    
+
+    last = (0, 0)    
     while events[ROBOTICSBASE_STOP_LISTENER].is_set() == False:
+        # Sleep before starting next cycle
+        time.sleep(CONTROLLER_SLEEP_INTERVAL)
+
         # Button logic
         for event in pygame.event.get():
             if event.type == JOYBUTTONDOWN:
@@ -59,8 +63,10 @@ def joystick_listener(host, port, events, lock, joystick):
 
         # Joystick logic
         (x,y) = get_joystick_value(joystick)
-        
         print "X: %d\nY: %d" % (x,y)
+
+        if (x,y) == last:
+            continue
 
         if x < (-20) and y >= 0:
             print "forward left %d" % x
@@ -90,7 +96,8 @@ def joystick_listener(host, port, events, lock, joystick):
             print "stop"
             send_locked_command(client, lock, ROBOTICSNET_COMMAND_STOP)
         
-        time.sleep(CONTROLLER_SLEEP_INTERVAL)
+        # Save joystick value
+        last = (x,y)
     
     # send one final stop command. Reset controller stop event
     send_locked_command(client, lock, ROBOTICSNET_COMMAND_STOP)

--- a/roboticsbase/joystick_listener.py
+++ b/roboticsbase/joystick_listener.py
@@ -101,7 +101,6 @@ def joystick_listener(host, port, events, lock, joystick):
     
     # send one final stop command. Reset controller stop event
     send_locked_command(client, lock, ROBOTICSNET_COMMAND_STOP)
-    events[ROBOTICSBASE_STOP_LISTENER].clear()
 
 def spawn_joystick_process(host, port, events, lock):
     """
@@ -111,6 +110,7 @@ def spawn_joystick_process(host, port, events, lock):
     """
     
     pygame.init()
+    events[ROBOTICSBASE_STOP_LISTENER].clear()
     
     try:
         joystick = get_joystick()

--- a/roboticsbase/joystick_listener.py
+++ b/roboticsbase/joystick_listener.py
@@ -35,7 +35,7 @@ def get_joystick_value(joystick):
     
     return (x,y)
 
-def input_listener(host, port, events, lock, joystick):
+def joystick_listener(host, port, events, lock, joystick):
     """
     Main movement control thread - interprets commands from joystick and sends them to rover.
     """
@@ -88,9 +88,9 @@ def input_listener(host, port, events, lock, joystick):
     send_locked_command(client, lock, ROBOTICSNET_COMMAND_STOP)
     events[ROBOTICSBASE_STOP_LISTENER].clear()
 
-def spawn_input_process(host, port, events, lock):
+def spawn_joystick_process(host, port, events, lock):
     """
-    Spawns an input process, which gets input from keyboard or controller and sends it to the rover.
+    Spawns a joystick input process, which gets input from controller and sends it to the rover.
     events is an array of process events that keep track of basestation events (Such as the stream video command and whether the controller is active)
     lock is a process lock which prevents clients from sending messages concurrently
     """
@@ -101,11 +101,11 @@ def spawn_input_process(host, port, events, lock):
         joystick = get_joystick()
         joystick.init()
         
-        input_process = multiprocessing.Process(target=input_listener, args=(host, port, events, lock, joystick))
-        input_process.start()
+        joystick_process = multiprocessing.Process(target=joystick_listener, args=(host, port, events, lock, joystick))
+        joystick_process.start()
         
         # Wait for process to finish, then deinit pygame
-        input_process.join()
+        joystick_process.join()
         
     except InputException as e:
         print "Input error!"
@@ -122,7 +122,7 @@ def main():
     port = int(raw_input("Enter port: "))
     events = [multiprocessing.Event() for i in range(ROBOTICSBASE_NUM_EVENTS)]
     lock = multiprocessing.Lock()
-    spawn_input_process(host, port, events, lock)
+    spawn_joystick_process(host, port, events, lock)
     
 main()
 

--- a/roboticsbase/joystick_listener.py
+++ b/roboticsbase/joystick_listener.py
@@ -64,19 +64,19 @@ def input_listener(host, port, events, lock, joystick):
 
         if x < (-20) and y >= 0:
             print "forward left %d" % x
-            send_command(ROBOTICSNET_COMMAND_FORWARDLEFT, host, port, -x/2)
+            send_locked_command(client, lock, ROBOTICSNET_COMMAND_FORWARDLEFT, -x/2)
 
         elif x > (20) and y >= 0:
             print "forward right %d" % x
-            send_command(ROBOTICSNET_COMMAND_FORWARDRIGHT, host, port, x/2)
+            send_locked_command(client, lock, ROBOTICSNET_COMMAND_FORWARDRIGHT, x/2)
 
         elif x < (-20) and y < 0:
             print "reversing left %x" % x
-            send_command(ROBOTICSNET_COMMAND_REVERSELEFT, host, port, x/2)
+            send_locked_command(client, lock, ROBOTICSNET_COMMAND_REVERSELEFT, x/2)
 
         elif x > 20 and y < 0:
             print "reversing right %d" % x
-            send_command(ROBOTICSNET_COMMAND_REVERSERIGHT, host, port, x/2)
+            send_locked_command(client, lock, ROBOTICSNET_COMMAND_REVERSERIGHT, x/2)
 
         elif y > (10):
             print "forward %d" % y

--- a/roboticsbase/joystick_listener.py
+++ b/roboticsbase/joystick_listener.py
@@ -78,7 +78,7 @@ def joystick_listener(host, port, events, lock, joystick):
 
         elif x < (-20) and y < 0:
             print "reversing left %x" % x
-            send_locked_command(client, lock, ROBOTICSNET_COMMAND_REVERSELEFT, x/2)
+            send_locked_command(client, lock, ROBOTICSNET_COMMAND_REVERSELEFT, -x/2)
 
         elif x > 20 and y < 0:
             print "reversing right %d" % x

--- a/roboticsbase/joystick_listener.py
+++ b/roboticsbase/joystick_listener.py
@@ -61,15 +61,23 @@ def joystick_listener(host, port, events, lock, joystick):
         (x,y) = get_joystick_value(joystick)
         
         print "X: %d\nY: %d" % (x,y)
-        
-        if x < (-20):
-            print "left %d" % x
-            send_locked_command(client, lock, ROBOTICSNET_COMMAND_TURNLEFT, -x/2)
-            
-        elif x > (20):
-            print "right %d" % x
-            send_locked_command(client, lock, ROBOTICSNET_COMMAND_TURNRIGHT, x/2)
-            
+
+        if x < (-20) and y >= 0:
+            print "forward left %d" % x
+            send_locked_command(client, lock, ROBOTICSNET_COMMAND_FORWARDLEFT, -x/2)
+
+        elif x > (20) and y >= 0:
+            print "forward right %d" % x
+            send_locked_command(client, lock, ROBOTICSNET_COMMAND_FORWARDRIGHT, x/2)
+
+        elif x < (-20) and y < 0:
+            print "reversing left %x" % x
+            send_locked_command(client, lock, ROBOTICSNET_COMMAND_REVERSELEFT, x/2)
+
+        elif x > 20 and y < 0:
+            print "reversing right %d" % x
+            send_locked_command(client, lock, ROBOTICSNET_COMMAND_REVERSERIGHT, x/2)
+
         elif y > (10):
             print "forward %d" % y
             send_locked_command(client, lock, ROBOTICSNET_COMMAND_FORWARD, y)

--- a/roboticsbase/mjpg.py
+++ b/roboticsbase/mjpg.py
@@ -1,0 +1,93 @@
+import pygtk
+pygtk.require('2.0')
+import gtk
+import urllib
+import gobject
+import threading
+
+streamip=raw_input("Stream IP\n>")
+streamport=raw_input("Port\n>")
+
+
+STREAM_URL = 'http://'+streamip+":"+streamport+"/?action=stream"
+
+class VideoThread(threading.Thread):
+    '''
+    A background thread that takes the MJPEG stream and
+    updates the GTK image.
+    '''
+    def __init__(self, widget):
+        super(VideoThread, self).__init__()
+        self.widget = widget
+        self.quit = False
+        print 'connecting to', STREAM_URL
+        self.stream = urllib.urlopen(STREAM_URL)
+
+    def get_raw_frame(self):
+        '''
+        Parse an MJPEG http stream and yield each frame.
+        Source: http://stackoverflow.com/a/21844162
+
+        :return: generator of JPEG images
+        '''
+        raw_buffer = ''
+        while True:
+            new = self.stream.read(1034)
+            if not new:
+                # Connection dropped
+                yield None
+            raw_buffer += new
+            a = raw_buffer.find('\xff\xd8')
+            b = raw_buffer.find('\xff\xd9')
+            if a != -1 and b != -1:
+                frame = raw_buffer[a:b+2]
+                raw_buffer = raw_buffer[b+2:]
+                yield frame
+
+    def run(self):
+        for frame in self.get_raw_frame():
+            if self.quit or frame is None:
+                return
+            loader = gtk.gdk.PixbufLoader('jpeg')
+            loader.write(frame)
+            loader.close()
+            pixbuf = loader.get_pixbuf()
+            # Schedule image update to happen in main thread
+            gobject.idle_add(self.widget.set_from_pixbuf, pixbuf)
+
+if __name__=="__main__":
+    gobject.threads_init()
+    window = gtk.Window(gtk.WINDOW_TOPLEVEL)
+    window.connect("destroy", gtk.main_quit)
+    window.set_border_width(10)
+    
+    img = gtk.Image()
+    img.show()
+    main_box=gtk.VBox()
+    main_box.show()
+    button1 = gtk.Button("This is button1")
+    button2 = gtk.Button("This is button2")
+    main_box.pack_start(img)
+    widget_box = gtk.HBox(False, 0)
+    widget_box.pack_start(button1)    # test button
+    widget_box.pack_start(button2)    # test button
+    exit_button = gtk.Button(stock=gtk.STOCK_QUIT)
+    exit_button.connect("clicked", destroy)
+    widget_box.pack_start(exit_button)
+    main_box.pack_start(widget_box)
+    window.add(main_box)
+    window.show_all()
+
+
+        # Used when closing window.
+    window.connect("delete_event", delete_event)
+    window.connect("destroy", destroy)
+
+    t = VideoThread(img)
+    window.show()
+    t.start()
+    gtk.main()
+    t.quit = True
+
+
+

--- a/roboticsbase/send_command.py
+++ b/roboticsbase/send_command.py
@@ -17,10 +17,14 @@ def send_locked_command(client, lock, command, value=0):
             client.forward(value)
         elif (command == ROBOTICSNET_COMMAND_REVERSE):
             client.reverse(value)
-        elif (command == ROBOTICSNET_COMMAND_TURNLEFT):
-            client.turnLeft(value)
-        elif (command == ROBOTICSNET_COMMAND_TURNRIGHT):
-            client.turnRight(value)
+        elif (command == ROBOTICSNET_COMMAND_FORWARDLEFT):
+            client.forwardLeft(value)
+        elif (command == ROBOTICSNET_COMMAND_FORWARDRIGHT):
+            client.forwardRight(value)
+        elif (command == ROBOTICSNET_COMMAND_REVERSELEFT):
+            client.reverseLeft(value)
+        elif (command == ROBOTICSNET_COMMAND_REVERSERIGHT):
+            client.reverseRight(value)
         elif (command == ROBOTICSNET_COMMAND_STOP):
             client.stop()
         elif (command == ROBOTICSNET_COMMAND_QUERYPROC):

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ import gtk
 
 # requirements and links can be added and removed here. PyGTK does not support distutils on linux so it is not included for now.
 REQUIREMENTS = [
-    'roboticsnet',
-    'pygame>=1.9'
+    'roboticsnet'#,
+    #'pygame>=1.9'
 ]
 
 DEPENDENCY_LINKS = [

--- a/setup.py
+++ b/setup.py
@@ -9,12 +9,11 @@ import gtk
 
 # requirements and links can be added and removed here. PyGTK does not support distutils on linux so it is not included for now.
 REQUIREMENTS = [
-    'roboticsnet',
     'pygame>=1.9'
 ]
 
 DEPENDENCY_LINKS = [
-    'https://github.com/space-concordia-robotics/robotics-networking/tarball/master#egg=roboticsnet',
+    'https://github.com/space-concordia-robotics/robotics-networking/tarball/master#egg=roboticsnet-0.1.0',
     'https://github.com/xamox/pygame/tarball/master#egg=pygame-1.9.1'
 ]
 
@@ -26,7 +25,7 @@ setup(
     long_description=open('README.rst').read(),
     url='https://github.com/space-concordia-robotics/robotics-basestation',
     license='MIT',
-    
+
     author='TBD',
 
     install_requires=REQUIREMENTS,
@@ -34,7 +33,8 @@ setup(
 
     packages=['roboticsbase'],
     zip_safe=False,
-    scripts=['roboticsbase/bin/roboticsbase-test']
-    
+    scripts=['roboticsbase/bin/roboticsbase-test'],
+    test_suite="test"
+
 )
 

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,6 @@ from setuptools import setup, find_packages
 
 import roboticsbase
 
-import pygtk
-pygtk.require('2.0')
-import gtk
-
-
 # requirements and links can be added and removed here. PyGTK does not support distutils on linux so it is not included for now.
 REQUIREMENTS = [
     'pygame>=1.9'

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ import roboticsbase
 
 # requirements and links can be added and removed here. PyGTK does not support distutils on linux so it is not included for now.
 REQUIREMENTS = [
-    'pygame'
 ]
 
 DEPENDENCY_LINKS = [

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import roboticsbase
 
 # requirements and links can be added and removed here. PyGTK does not support distutils on linux so it is not included for now.
 REQUIREMENTS = [
-    'pygame>=1.9'
+    'pygame'
 ]
 
 DEPENDENCY_LINKS = [

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     license='MIT',
 
     author='TBD',
+    author_email='TBD@TBD.TBD',
 
     install_requires=REQUIREMENTS,
     dependency_links=DEPENDENCY_LINKS,

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ import roboticsbase
 
 # requirements and links can be added and removed here. PyGTK does not support distutils on linux so it is not included for now.
 REQUIREMENTS = [
+    'roboticsnet',
 ]
 
 DEPENDENCY_LINKS = [

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ REQUIREMENTS = [
 
 DEPENDENCY_LINKS = [
     'https://github.com/space-concordia-robotics/robotics-networking/tarball/master#egg=roboticsnet-0.1.0',
-    'https://github.com/xamox/pygame/tarball/master#egg=pygame-1.9.1'
 ]
 
 setup(

--- a/test/test_sanity.py
+++ b/test/test_sanity.py
@@ -1,0 +1,6 @@
+import unittest
+
+class TestSanity(unittest.TestCase):
+
+    def testSanity(self):
+        self.assertEqual(1, 1)


### PR DESCRIPTION
This ended up being a little more messed up than what was anticipated. You can take a look at the travis configuration file to see what I mean.

I had to reorganize a few dependencies to get the travis build to work. It seems that the sanest course of installing `PyGTK` and `Pygame` is via the distribution's recommended way. 

I've added a few checks for the dependencies via catch blocks. If the user tries to run the application through the default script, it should print instructions to install the required dependencies manually. This is the best that can be done I think.

``` python
try:
    import pygtk
    pygtk.require('2.0')
    import gtk
except ImportError:
    print "You need pygtk 2.x in order to run the basestation software"
    print "Install pygtk via your distributions recommended way."
    exit()

try:
    import pygame
except ImportError:
    print "You need to install pygame 1.9.x"
    print "Install pygame via your distributions recommended way."
    exit()

# ...
```

**NB**: I had to pull in the changes which are happening in the other branch to test this functionality (the other branch can be developed upon and merged against master to update - there shouldn't be any issues).

Closes #11 
Closes #7 
Closes #3
